### PR TITLE
Add set_not_accessible_error_callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ $ u.name
 => "Taro"
 
 $ u.age
-=> FieldMaskedModel::NotAccessibleError: age is not specified as paths in field_mask!
+=> FieldMaskedModel::InaccessibleError: age is not specified as paths in field_mask!
 
 $ u.profile
 => <Profile

--- a/lib/field_masked_model/error.rb
+++ b/lib/field_masked_model/error.rb
@@ -1,4 +1,4 @@
 module FieldMaskedModel
   class Error < StandardError; end
-  class NotAccessibleError < Error; end
+  class InaccessibleError < Error; end
 end


### PR DESCRIPTION
## WHY
Sometimes we want to use custom error handler.

## WHAT
Added `inaccessible_error_callback` method to `FieldMaskedModel::Base`.
I also changed the default error class from `FieldMaskedModel::NotAccessibleError` to `FieldMaskedModel::InaccessibleError`
