### PR TITLE
Update runtime dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     field_masked_model (0.3.0)
       fmparser (= 0.1.0)
-      google-protobuf (~> 3.7)
+      google-protobuf (~> 3.2)
 
 GEM
   remote: https://rubygems.org/
@@ -11,7 +11,7 @@ GEM
     coderay (1.1.2)
     diff-lcs (1.3)
     fmparser (0.1.0)
-    google-protobuf (3.9.0)
+    google-protobuf (3.9.1)
     method_source (0.9.2)
     pry (0.12.2)
       coderay (~> 1.1.0)

--- a/field_masked_model.gemspec
+++ b/field_masked_model.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.11"
   spec.add_development_dependency "rspec", "~> 3.8"
   spec.add_runtime_dependency "fmparser", "0.1.0"
-  spec.add_runtime_dependency "google-protobuf", "~> 3.7"
+  spec.add_runtime_dependency "google-protobuf", "~> 3.2"
 end


### PR DESCRIPTION
## WHY
field_masked_model does not need `google-protobuf 3.7` .This is too restrictive setting.

## WHAT
Update runtime dependency.